### PR TITLE
Refactor getFilamentName() method

### DIFF
--- a/modules/User/Entities/User.php
+++ b/modules/User/Entities/User.php
@@ -75,7 +75,7 @@ class User extends Authenticatable implements FilamentUser, HasName
      * @return string
      */
     public function getFilamentName(): string
-    {
-        return "$this->first_name $this->last_name";
+    { 
+        return "$this->getAttribute(UserMCF::FULL_NAME)";
     }
 }


### PR DESCRIPTION
Update getFilamentName() method in the User Model  to use $this->getAttribute(UserMCF::FULL_NAME) for filament user display name.